### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/handlers/portfolio.go
+++ b/handlers/portfolio.go
@@ -375,7 +375,30 @@ func GetMyPortfolios(c *gin.Context) {
 	dbQuery.Count(&total)
 
 	offset := (query.Page - 1) * query.PageSize
-	orderBy := query.SortBy + " " + query.Order
+
+	// Whitelist allowed sorting columns and ordering directions
+	allowedSortBy := map[string]bool{
+		"created_at": true,
+		"title":      true,
+		"category":   true,
+		"status":     true,
+		// Add any other allowed fields here, must match model/DB column names
+	}
+	allowedOrder := map[string]string{
+		"asc":  "ASC",
+		"ASC":  "ASC",
+		"desc": "DESC",
+		"DESC": "DESC",
+	}
+	sortBy := "created_at" // default field
+	order := "DESC"         // default order
+	if allowedSortBy[query.SortBy] {
+		sortBy = query.SortBy
+	}
+	if val, ok := allowedOrder[query.Order]; ok {
+		order = val
+	}
+	orderBy := sortBy + " " + order
 
 	err := dbQuery.Order(orderBy).Offset(offset).Limit(query.PageSize).Find(&portfolios).Error
 	if err != nil {


### PR DESCRIPTION
Potential fix for [https://github.com/oldweipro/design-ai/security/code-scanning/2](https://github.com/oldweipro/design-ai/security/code-scanning/2)

To safely handle user-controlled sorting parameters, we must strictly validate and whitelist both the `SortBy` (column) and `Order` (direction) values before interpolation into the query string. 

- For `SortBy`, only allow a fixed list of field names that are valid portfolio columns (e.g., `"created_at"`, `"title"`, `"category"`).
- For `Order`, only allow `"asc"` or `"desc"` (case-insensitive).
- Any value not in the allowed list should default to a safe value.
- Construct the `orderBy` string from these validated variables.

**Specific edits:**
- Add definitions (lists/maps) to hold allowed field names/directions at the top of the function or file.
- Add code before building `orderBy` that checks `query.SortBy` and `query.Order` for whitelisted values, and substitutes defaults if they are not.
- Update the construction of `orderBy` to always use the validated/whitelisted values.

No additional dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
